### PR TITLE
Add Token Gated Hook

### DIFF
--- a/hook-modules.json
+++ b/hook-modules.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "TokenGatedHook",
-    "address": "0x497affcb5581eaa5684104a9cb6c4c49fc621291",
-    "blockExplorerLink": "https://sepolia.etherscan.io/address/0x497affcb5581eaa5684104a9cb6c4c49fc621291#code"
+    "address": "0x4C4211CDDb2Afe335D63EBA6138D743d2af81ccf",
+    "blockExplorerLink": "https://sepolia.etherscan.io/address/0x4C4211CDDb2Afe335D63EBA6138D743d2af81ccf#code"
   }
 ]


### PR DESCRIPTION
# Registered my module

- Module type:  `hook`
- Module name: `TokenGatedHook`
- Module address: `0x4C4211CDDb2Afe335D63EBA6138D743d2af81ccf`
- My module is immutable: yes
- My module is using an upgradeable proxy: no
- My module has been verified on the block explorer: yes
- Summary of my module: Hook for ensuring the caller is the owner of an NFT token.
