### PR TITLE
Add IP/USD Pricing Hook based on Pyth Price Feed

### DIFF
--- a/hook-modules.json
+++ b/hook-modules.json
@@ -3,5 +3,10 @@
     "name": "TokenGatedHook",
     "address": "0x4C4211CDDb2Afe335D63EBA6138D743d2af81ccf",
     "blockExplorerLink": "https://sepolia.etherscan.io/address/0x4C4211CDDb2Afe335D63EBA6138D743d2af81ccf#code"
+  },
+  {
+    "name": "IPUSDPricingHook",
+    "address": "0x72ae893035c7a3a810ac029a5d785b7a849cef19",
+    "blockExplorerLink": "https://aeneid.storyscan.io/address/0x72ae893035c7a3a810ac029a5d785b7a849cef19?tab=contract"
   }
 ]


### PR DESCRIPTION
- Module type: hook
- Module name: IP_USD_PRICING_HOOK
- Module address: 0x72ae893035c7a3a810ac029a5d785b7a849cef19
- My module is immutable: yes
- My module is using an upgradeable proxy: no
- My module has been verified on the block explorer: yes
- Summary of my module: Pricing hook to calculate license price in USD to IP using Pyth price feed.